### PR TITLE
add SWIG as prerequisite

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A working [GNURadio](https://gnuradio.org) installation with the following compo
  - FFT
  - Filter
  - Python
+ - SWIG
 
 No other OOT module is needed.
 


### PR DESCRIPTION
without installing SWIG I'm running into the `AttributeError: 'module' object has no attribute 'fft_burst_tagger'` from https://github.com/muccc/gr-iridium/issues/7 on ubuntu 15.10.
What do you think about making CMake abort if it can't find SWIG?