### PR TITLE
Adding support for defined antennas in config files and an example file for a Lime SDR.

### DIFF
--- a/examples/limesdr-10msps.conf
+++ b/examples/limesdr-10msps.conf
@@ -1,0 +1,12 @@
+[osmosdr-source]
+
+# limesdr DOES NOT support bias tee for active antennas, you WILL need an LNA with its own power supply to make this work.
+device_args='driver=lime,soapy=0'
+
+sample_rate=10000000
+center_freq=1622000000
+bandwidth=9000000
+antenna=LNAH # Getting best results with this input.
+
+# Set gain
+gain=30

--- a/examples/limesdr-10msps.conf
+++ b/examples/limesdr-10msps.conf
@@ -6,7 +6,7 @@ device_args='driver=lime,soapy=0'
 sample_rate=10000000
 center_freq=1622000000
 bandwidth=9000000
-antenna=LNAH # Getting best results with this input.
+antenna=LNAH
 
 # Set gain
 gain=30

--- a/python/iridium_extractor_flowgraph.py
+++ b/python/iridium_extractor_flowgraph.py
@@ -139,6 +139,13 @@ class FlowGraph(gr.top_block):
                 source.set_bandwidth(0, 0)
                 print >> sys.stderr, "Warning: Setting bandwidth to", source.get_bandwidth(0)
 
+            if 'antenna' in d:
+                antenna = d['antenna']
+                source.set_antenna(antenna, 0)
+                print >> sys.stderr, "Antenna:", source.get_antenna(0), '(Requested %s)' % antenna
+            else:
+                print >> sys.stderr, "Warning: Setting antenna to", source.get_antenna(0)
+
             #source.set_freq_corr($corr0, 0)
             #source.set_dc_offset_mode($dc_offset_mode0, 0)
             #source.set_iq_balance_mode($iq_balance_mode0, 0)


### PR DESCRIPTION
Tested with my own Lime SDR USB board, sample output below.

rjmendez@Risk:~/development/rjmendez/gr-iridium$ iridium-extractor ~/development/rjmendez/gr-iridium/examples/limesdr-10msps.conf
linux; GNU C++ version 5.4.0 20160609; Boost_105800; UHD_3.11.0.git-71-g2016126f

gr-osmosdr v0.1.4-77-g2a2236cc (0.1.5git) gnuradio v3.7.10.1-237-g81e7af7b
built-in source types: file osmosdr fcd rtl rtl_tcp uhd hackrf bladerf rfspace airspy soapy redpitaya
[INFO] Make connection: 'LimeSDR-USB [USB 2.0] 9060B0049260B'
[INFO] Estimated reference clock 30.7197 MHz
[INFO] Selected reference clock 30.720 MHz
[INFO] Device name: LimeSDR-USB
[INFO] Reference: 30.72 MHz
[INFO] Init LMS7002M(0)
[INFO] LMS7002M cache /home/rjmendez/.limesuite/LMS7002M_cache_values.db
[INFO] Ver=7, Rev=1, Mask=1
[INFO] LMS7002M calibration values caching Enable
[INFO] Rx Filter calibrated from cache
[INFO] Tx Filter calibrated from cache
[INFO] Rx Filter calibrated from cache
[INFO] Tx Filter calibrated from cache
SetFrequency using cache values vco:1, csw:219
(RF) Gain: 42.0 (Requested 30)
[INFO] Rx Filter calibrated from cache
Bandwidth: 9000000.0 (Requested 9000000)
Antenna: NONE (Requested LNAH)
1496479807 | i:   0/s | i_avg:   0/s | q:    0 | q_max:    0 | o:   0/s | ok:   0% | ok:   0/s | ok_avg:   0% | ok:          0 | ok_avg:   0/s | d: 0
############################################################
Rx calibration using RSSI INTERNAL ON BOARD loopback
Rx ch.A @ 1622 MHz, BW: 9 MHz, RF input: LNAH, PGA: 12, LNA: 15, TIA: 1
Rx calibration: using cached values
Rx calibration values found in cache:
   | DC  | GAIN | PHASE
---+-----+------+------
I: |   0 | 2047 | 0
Q: |   0 | 2047 |
############################################################
[INFO] L 1392640
1496479808 | i:   0/s | i_avg:   0/s | q:    0 | q_max:    1 | o:   0/s | ok:   0% | ok:   0/s | ok_avg:   0% | ok:          0 | ok_avg:   0/s | d: 0
RAW: i-1496479807-t1 0001147 1626263168 A:OK I:00000000002  83% 0.000 137 0011000000110000111100110010010100101101011000010010000001010011001000110011110011110000111111011010100110010011111100011100010001010111100001110010011100000000101010100010010111000100111111111111100111111011011111111111111111111111100111111111111110010111101011011011001100111110101011001101100000
RAW: i-1496479807-t1 0001391 1625721344 A:OK I:00000000007  95% 0.000 179 0011000000110000111100110011001000110011000100000101101001100011001101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010011010101010101010101010101010101010101010101010101010101010101010101010101010011010101010101010101010101010101010101010101010101
1496479809 | i:   7/s | i_avg:   0/s | q:    0 | q_max:    2 | o:   7/s | ok:  25% | ok:   1/s | ok_avg:  22% | ok:          2 | ok_avg:   0/s | d: 0
RAW: i-1496479807-t1 0002317 1626429568 A:OK I:00000000055  97% 0.000 133 00110000001100001111001100110011111100110011001111110011010000000110010010110000001100010000101110001000001011001100011000000000000000000000000000000000000000000000000000000000000000001100110011001100110011001100110011001100110011001100110011001100100101111010110110110011001111001100100001
RAW: i-1496479807-t1 0002587 1626429440 A:OK I:00000000061 100% 0.000 129 001100000011000011110011001100111111001100110011111100110110000101010111100000000011000100101000100110000010110011000110000000000000000000000000000000000000000000000000000000000000000011001100110011001100110011001100110011001100110011001100110011001001011110101101101100110011110101
