### PR TITLE
Fix broken test

### DIFF
--- a/lib/qa_fft_burst_tagger.cc
+++ b/lib/qa_fft_burst_tagger.cc
@@ -30,7 +30,17 @@ namespace gr {
     void
     qa_fft_burst_tagger::t1()
     {
-      fft_burst_tagger::make(1024, 1000000, 1000, 1000, 100, 0, 7.0, 512, false);
+      //
+      fft_burst_tagger::make(1626000000, /* center_frequency */
+                             4096, /* fft_size */
+                             1000000, /* sample_rate */
+                             4096,  /* burst_pre_len */
+                             8*4096,  /* burst_post_len */
+                             40,  /* burst_width */
+                             0,  /* max_bursts */
+                             7.0,  /* threshold */
+                             512, /* history_size */
+                             false  /*  debug*/);
     }
 
   } /* namespace iridium */


### PR DESCRIPTION
Set the test args to fft_burst_tagger::make to be simlar to real world
values. This fixes the test and issue #21.