### PR TITLE
Add support for CI testing using travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+dist: trusty
+sudo: required
+services:
+  - docker
+language: cpp
+branches:
+  - travis
+install:
+  - .travis/build-docker-image.sh "builder-v1"
+script:
+  - docker run -it -d -v "$(pwd):/code" --name builder "builder-v1"
+  - docker exec builder cmake /code
+  - docker exec builder make
+  - docker exec builder make test
+cache:
+  directories:
+    - docker

--- a/.travis/build-docker-image.sh
+++ b/.travis/build-docker-image.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -ev
+
+# Increment version number to flush cache if required
+TAG="${1}"
+echo "Using tag ${TAG}"
+
+# Create cache folder when running outside Travis
+if [ -d "docker" ]; then
+    echo "Found existing docker cache folder"
+else
+    mkdir docker
+fi
+
+# Load any image from cache if available
+CACHE_FROM=""
+if [ -f "docker/${TAG}.tar.gz" ]; then
+    gzip -dc "docker/${TAG}.tar.gz" | docker load
+    CACHE_FROM="${TAG}"
+fi
+
+# build the image
+docker build --cache-from="${CACHE_FROM}" --tag="${TAG}" --file=".travis/builder.dockerfile" .travis
+
+# Save Docker image to cache
+if [ -f "docker/${TAG}.tar.gz" ]; then
+    echo "Leaving cache unchanged"
+else
+    docker save "${TAG}" | gzip > docker/${TAG}.tar.gz
+fi
+
+# Clean cache of any previous versions
+ls -ahls docker
+find docker/ -type f ! -name "${TAG}.tar.gz" -delete
+ls -ahls docker

--- a/.travis/builder.dockerfile
+++ b/.travis/builder.dockerfile
@@ -1,0 +1,13 @@
+FROM debian:buster-slim
+
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    gnuradio gnuradio-dev \
+    libvolk1.4 libvolk1-dev \
+    cmake build-essential \
+    python python-dev python-scipy swig \
+    libboost-dev libcppunit-dev
+
+RUN mkdir /build
+WORKDIR /build

--- a/lib/qa_fft_burst_tagger.cc
+++ b/lib/qa_fft_burst_tagger.cc
@@ -30,7 +30,17 @@ namespace gr {
     void
     qa_fft_burst_tagger::t1()
     {
-      fft_burst_tagger::make(1024, 1000000, 1000, 1000, 100, 0, 7.0, 512, false);
+      //
+      fft_burst_tagger::make(1626000000, /* center_frequency */
+                             4096, /* fft_size */
+                             1000000, /* sample_rate */
+                             4096,  /* burst_pre_len */
+                             8*4096,  /* burst_post_len */
+                             40,  /* burst_width */
+                             0,  /* max_bursts */
+                             7.0,  /* threshold */
+                             512, /* history_size */
+                             false  /*  debug*/);
     }
 
   } /* namespace iridium */


### PR DESCRIPTION
This uses Docker to build on the Travis CI platform. This runs all tests
and should represent the ideal "enviroment" using Debian Buster and a
clean GNURadio install.

Note: This has the #29 pull request as well as it was needed to get the Travis builds to pass