### PR TITLE
cmake: make sure Python bindings can be built

### DIFF
--- a/swig/CMakeLists.txt
+++ b/swig/CMakeLists.txt
@@ -29,11 +29,8 @@ endif(NOT iridium_sources)
 ########################################################################
 # Include swig generation macros
 ########################################################################
-find_package(SWIG)
-find_package(PythonLibs)
-if(NOT SWIG_FOUND OR NOT PYTHONLIBS_FOUND)
-    return()
-endif()
+find_package(SWIG REQUIRED)
+find_package(PythonLibs REQUIRED)
 include(GrSwig)
 include(GrPython)
 


### PR DESCRIPTION
Closes #83 