### PR TITLE
Reset noise estimate on too many burst squelches

### DIFF
--- a/lib/fft_burst_tagger_impl.cc
+++ b/lib/fft_burst_tagger_impl.cc
@@ -177,7 +177,7 @@ namespace gr {
       return true;
     }
            
-#define HIST(i) (d_baseline_history_f + (i % d_history_size) * d_fft_size)
+#define HIST(i) (d_baseline_history_f + i * d_fft_size)
     void
     fft_burst_tagger_impl::update_filters_post(void)
     {
@@ -191,6 +191,7 @@ namespace gr {
 
         if(d_history_index == d_history_size) {
           d_history_primed = true;
+          d_history_index = 0;
         }
       }
     }

--- a/lib/fft_burst_tagger_impl.cc
+++ b/lib/fft_burst_tagger_impl.cc
@@ -65,6 +65,7 @@ namespace gr {
         d_burst_id(0),
         d_sample_count(0),
         d_n_tagged_bursts(0),
+        d_squelch_count(0),
         d_fft(NULL), d_history_size(history_size), d_peaks(std::vector<peak>()),
         d_bursts(std::vector<burst>()), d_history_primed(false), d_history_index(0),
         d_burst_post_len(burst_post_len), d_debug(debug), d_burst_debug_file(NULL),
@@ -271,6 +272,23 @@ namespace gr {
           }
         }
         d_bursts.clear();
+        update_burst_mask(); 
+
+        d_squelch_count += 3;
+        // If we get too many squelches our noise floor might be significantly off
+        // and the normal adjustments are not good enough.
+        if(d_squelch_count >= 10) {
+            fprintf(stderr, "Resetting noise estimate\n");
+            d_history_index = 0;
+            d_history_primed = 0;
+            memset(d_baseline_history_f, 0, sizeof(float) * d_fft_size * d_history_size);
+            memset(d_baseline_sum_f, 0, sizeof(float) * d_fft_size);
+            d_squelch_count = 0;
+        }
+      } else {
+        if(d_squelch_count) {
+            d_squelch_count--;
+        }
       }
     }
 

--- a/lib/fft_burst_tagger_impl.h
+++ b/lib/fft_burst_tagger_impl.h
@@ -57,6 +57,7 @@ namespace gr {
       int d_burst_post_len;
       int d_max_bursts;
       int d_sample_rate;
+      int d_squelch_count;
       uint64_t d_index;
       uint64_t d_burst_id;
       uint64_t d_n_tagged_bursts;


### PR DESCRIPTION
Example when powering up an active antenna with the SDR already running:
```
1648423956 | i:   0/s | i_avg:   0/s | q_max:    0 | i_ok:   0% | o:    0/s | ok:   0% | ok:   0/s | ok_avg:   0% | ok:          0 | ok_avg:   0/s | d: 0
1648423957 | i:   0/s | i_avg:   0/s | q_max:    0 | i_ok:   0% | o:    0/s | ok:   0% | ok:   0/s | ok_avg:   0% | ok:          0 | ok_avg:   0/s | d: 0
Detector in burst squelch at 99.363228
Detector in burst squelch at 99.364044
Detector in burst squelch at 99.364861
Detector in burst squelch at 99.365685
Resetting noise estimate
1648423958 | i:   0/s | i_avg:   0/s | q_max:    0 | i_ok:   0% | o:    0/s | ok:   0% | ok:   0/s | ok_avg:   0% | ok:          0 | ok_avg:   0/s | d: 0
1648423959 | i:   4/s | i_avg:   0/s | q_max:    1 | i_ok:  80% | o:    4/s | ok:  80% | ok:   3/s | ok_avg:  50% | ok:          4 | ok_avg:   0/s | d: 0
1648423960 | i:   7/s | i_avg:   0/s | q_max:    2 | i_ok: 100% | o:    8/s | ok: 100% | ok:   7/s | ok_avg:  75% | ok:         12 | ok_avg:   0/s | d: 0
```