### PR TITLE
use timestamp from sigmf as default

### DIFF
--- a/apps/iridium-extractor
+++ b/apps/iridium-extractor
@@ -261,6 +261,13 @@ if __name__ == "__main__":
             fmt = sigmf['global']['core:datatype']
         except:
             print("[sigmf] datatype missing.", file=sys.stderr)
+        try:
+            import datetime
+            dt = datetime.datetime.fromisoformat(sigmf['captures'][0]['core:datetime'].replace("Z", "+00:00"))
+            if args.file_info is None:
+                args.file_info = f'i-{dt.timestamp():.20g}-t1'
+        except:
+            print("[sigmf] timestamp missing.", file=sys.stderr)
 
     if args.sample_rate is not None:
         sample_rate = args.sample_rate

--- a/test-data/prbs15-2M-20dB.sigmf-meta
+++ b/test-data/prbs15-2M-20dB.sigmf-meta
@@ -7,7 +7,6 @@
     },
     "captures": [
         {
-            "core:datetime": "2020-09-29T23:14:06Z",
             "core:frequency": 1622000000,
             "core:sample_start": 0
         }


### PR DESCRIPTION
pyhon < 3.11 can't parse "Z", thus replace it with "+00:00"