### PR TITLE
Fix multiplicity typo in QPSK demod YAML

### DIFF
--- a/grc/iridium_iridium_qpsk_demod.block.yml
+++ b/grc/iridium_iridium_qpsk_demod.block.yml
@@ -13,7 +13,7 @@ parameters:
 inputs:
 -   domain: message
     id: cpdus
-    multiplicity: ${channel}
+    multiplicity: ${channels}
 
 outputs:
 -   domain: message


### PR DESCRIPTION
Fixes https://github.com/muccc/gr-iridium/issues/213 and https://github.com/gnuradio/gnuradio/issues/7734